### PR TITLE
fix missing semicolon (travis build fail)

### DIFF
--- a/src/nodes/ios/armodel-download-experiment.ts
+++ b/src/nodes/ios/armodel-download-experiment.ts
@@ -41,6 +41,6 @@ export class ARModel extends ARCommonNode {
           },
           (e: any) => reject(e)
       );
-    })
+    });
   }
 }


### PR DESCRIPTION
fix travis build fails with error: ERROR: nodes/ios/armodel-download-experiment.ts[44, 7]: Missing semicolon