### PR TITLE
set node properties at runtime (ios and android)

### DIFF
--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -199,7 +199,7 @@ export abstract class ARCommonNode implements IARCommonNode {
   remove(): void {
     // TODO would be nice if we could delete it from the cache.. perhaps move it to this common class as a static prop?
     // ARState.shapes.delete(this.id);
-    // this.ios.removeFromParentNode(); // TODO
+    this.android.setParentNode(null);
   }
 
   protected static getDefaultMaterial(): Promise<com.google.ar.sceneform.rendering.Material> {

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -119,6 +119,7 @@ export abstract class ARCommonNode implements IARCommonNode {
     );
   }
 
+
   rotateBy(by: ARRotation): void {
     const currentRotation = this.android.getLocalRotation();
     const rotateBy=new (<any>com.google.ar.sceneform).math.Quaternion(
@@ -172,6 +173,10 @@ export abstract class ARCommonNode implements IARCommonNode {
       node: this,
       touchPosition
     });
+  }
+
+  setVisible(visible: boolean): void {
+    this.android.setEnabled(visible);
   }
 
   allowDragging(): boolean {

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -154,6 +154,15 @@ export abstract class ARCommonNode implements IARCommonNode {
     );
   }
 
+  setScale(scale: number | ARScale): void {
+    this.android.setLocalScale(
+      new (<any>com.google.ar.sceneform).math.Vector3(
+        (scale instanceof ARScale ? scale.x : scale),
+        (scale instanceof ARScale ? scale.y : scale),
+        (scale instanceof ARScale ? scale.z : scale))
+    );
+  }
+
   onTap(touchPosition: ARDimensions2D): void {
     this.onTapHandler && this.onTapHandler({
       node: this,

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -121,12 +121,25 @@ export abstract class ARCommonNode implements IARCommonNode {
 
   rotateBy(by: ARRotation): void {
     const currentRotation = this.android.getLocalRotation();
+    const rotateBy=new (<any>com.google.ar.sceneform).math.Quaternion(
+        new (<any>com.google.ar.sceneform).math.Vector3(
+          by.x,
+          by.y,
+          by.z
+        )
+      );
+    this.android.setLocalRotation((<any>com.google.ar.sceneform).math.Quaternion.multiply(currentRotation, rotateBy) );
+  }
+
+  setRotation(rot: ARRotation): void {
     this.android.setLocalRotation(
       new (<any>com.google.ar.sceneform).math.Quaternion(
-        currentRotation.x + ARCommonNode.degToRadians(by.x),
-        currentRotation.y + ARCommonNode.degToRadians(by.y),
-        currentRotation.z + ARCommonNode.degToRadians(by.z),
-        1)
+        new (<any>com.google.ar.sceneform).math.Vector3(
+          rot.x,
+          rot.y,
+          rot.z
+        )
+      )
     );
   }
 

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -199,7 +199,7 @@ export abstract class ARCommonNode implements IARCommonNode {
   remove(): void {
     // TODO would be nice if we could delete it from the cache.. perhaps move it to this common class as a static prop?
     // ARState.shapes.delete(this.id);
-    this.android.setParentNode(null);
+    this.android.setParent(null);
   }
 
   protected static getDefaultMaterial(): Promise<com.google.ar.sceneform.rendering.Material> {

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -88,13 +88,33 @@ export abstract class ARCommonNode implements IARCommonNode {
     }));
   }
 
-  moveBy(by: ARRotation): void {
+  moveBy(by: ARPosition): void {
     const currentPosition = this.android.getLocalPosition();
     this.android.setLocalPosition(
       new (<any>com.google.ar.sceneform).math.Vector3(
         currentPosition.x + by.x,
         currentPosition.y + by.y,
         currentPosition.z + by.z
+      )
+    );
+  }
+
+  setPosition(pos: ARPosition): void {
+    this.android.setLocalPosition(
+      new (<any>com.google.ar.sceneform).math.Vector3(
+        pos.x,
+        pos.y,
+        pos.z
+      )
+    );
+  }
+
+  setWorldPosition(pos: ARPosition): void {
+    this.android.setWorldPosition(
+      new (<any>com.google.ar.sceneform).math.Vector3(
+        pos.x,
+        pos.y,
+        pos.z
       )
     );
   }

--- a/src/nodes/android/arcommongeometry.ts
+++ b/src/nodes/android/arcommongeometry.ts
@@ -22,25 +22,25 @@ export abstract class ARCommonGeometryNode extends ARCommonNode {
   protected static applyMaterial(node: com.google.ar.sceneform.Node, color: number): Promise<void> {
     return new Promise<void>((resolve, reject) => {
       com.google.ar.sceneform.rendering.MaterialFactory.makeOpaqueWithColor(
-          utils.ad.getApplicationContext(),
-          new com.google.ar.sceneform.rendering.Color(color))
-          .thenAccept(new java.util.function.Consumer({
-            accept: material => {
-              console.log("applyMaterial, material: " + material);
-              console.log("applyMaterial, node: " + node);
-              const renderable = node.getRenderable();
-              console.log("applyMaterial, renderable: " + renderable);
-              if (renderable) {
-                renderable.setMaterial(material);
-              }
-              resolve();
+        utils.ad.getApplicationContext(),
+        new com.google.ar.sceneform.rendering.Color(color))
+        .thenAccept(new java.util.function.Consumer({
+          accept: material => {
+            console.log("applyMaterial, material: " + material);
+            console.log("applyMaterial, node: " + node);
+            const renderable = node.getRenderable();
+            console.log("applyMaterial, renderable: " + renderable);
+            if (renderable) {
+              renderable.setMaterial(material);
             }
-          }));
+            resolve();
+          }
+        }));
     });
   }
 
- public setMaterials(materials: Array<number>): void {
-    ARCommonGeometryNode.applyMaterial(this.android, (<Color>materials[0]).android).catch(function(e){ console.log(e); });
+  public setMaterials(materials: Array<number>): void {
+    ARCommonGeometryNode.applyMaterial(this.android, (<Color>materials[0]).android).catch(function(e) { console.log(e); });
   }
 
 

--- a/src/nodes/android/arcommongeometry.ts
+++ b/src/nodes/android/arcommongeometry.ts
@@ -39,8 +39,9 @@ export abstract class ARCommonGeometryNode extends ARCommonNode {
     });
   }
 
-  public setMaterials(materials: Array<number>): void {
-    ARCommonGeometryNode.applyMaterial(this.android, materials[0]);
+ public setMaterials(materials: Array<number>): void {
+    ARCommonGeometryNode.applyMaterial(this.android, (<Color>materials[0]).android).catch(function(e){ console.log(e); });
   }
+
 
 }

--- a/src/nodes/android/arcommongeometry.ts
+++ b/src/nodes/android/arcommongeometry.ts
@@ -39,4 +39,8 @@ export abstract class ARCommonGeometryNode extends ARCommonNode {
     });
   }
 
+  public setMaterials(materials: Array<number>): void {
+    ARCommonGeometryNode.applyMaterial(this.android, materials[0]);
+  }
+
 }

--- a/src/nodes/ios/arcommon.ts
+++ b/src/nodes/ios/arcommon.ts
@@ -53,11 +53,31 @@ export abstract class ARCommonNode implements IARCommonNode {
     this.ios = node;
   }
 
-  moveBy(by: ARRotation): void {
+  moveBy(by: ARPosition): void {
     this.ios.position = {
       x: this.ios.position.x + by.x,
       y: this.ios.position.y + by.y,
       z: this.ios.position.z + by.z
+    };
+  }
+
+  setPosition(pos: ARPosition): void {
+
+    this.ios.position = {
+      x: pos.x,
+      y: pos.y,
+      z: pos.z
+    };
+  }
+
+  setWorldPosition(worldPos: ARPosition): void {
+
+    const pos = this.ios.convertPositionFrom(worldPos, null);
+
+    this.ios.position = {
+      x: pos.x,
+      y: pos.y,
+      z: pos.z
     };
   }
 
@@ -68,6 +88,8 @@ export abstract class ARCommonNode implements IARCommonNode {
       z: this.ios.eulerAngles.z + ARCommonNode.degToRadians(by.z)
     };
   }
+
+
 
   scaleBy(by: number | ARScale): void {
     this.ios.scale = {

--- a/src/nodes/ios/arcommon.ts
+++ b/src/nodes/ios/arcommon.ts
@@ -99,6 +99,14 @@ export abstract class ARCommonNode implements IARCommonNode {
     };
   }
 
+  setScale(scale: number | ARScale): void {
+    this.ios.scale = {
+      x: (scale instanceof ARScale ? scale.x : scale),
+      y: (scale instanceof ARScale ? scale.y : scale),
+      z: (scale instanceof ARScale ? scale.z : scale)
+    };
+  }
+
   onTap(touchPosition: ARDimensions2D): void {
     this.onTapHandler && this.onTapHandler({
       node: this,

--- a/src/nodes/ios/arcommon.ts
+++ b/src/nodes/ios/arcommon.ts
@@ -90,6 +90,14 @@ export abstract class ARCommonNode implements IARCommonNode {
   }
 
 
+  setRotation(rot: ARRotation): void {
+    this.ios.eulerAngles = {
+      x: ARCommonNode.degToRadians(rot.x),
+      y: ARCommonNode.degToRadians(rot.y),
+      z: ARCommonNode.degToRadians(rot.z)
+    };
+  }
+
 
   scaleBy(by: number | ARScale): void {
     this.ios.scale = {

--- a/src/nodes/ios/arcommon.ts
+++ b/src/nodes/ios/arcommon.ts
@@ -120,6 +120,10 @@ export abstract class ARCommonNode implements IARCommonNode {
     });
   }
 
+  setVisible(visible: boolean): void {
+    this.ios.hidden=!visible;
+  }
+
   allowDragging(): boolean {
     return this.draggingEnabled;
   }

--- a/src/nodes/ios/arcommon.ts
+++ b/src/nodes/ios/arcommon.ts
@@ -72,7 +72,7 @@ export abstract class ARCommonNode implements IARCommonNode {
 
   setWorldPosition(worldPos: ARPosition): void {
 
-    const pos = this.ios.convertPositionFrom(worldPos, null);
+    const pos = this.ios.convertPositionFromNode(worldPos, null);
 
     this.ios.position = {
       x: pos.x,

--- a/src/nodes/ios/arcommongeometry.ts
+++ b/src/nodes/ios/arcommongeometry.ts
@@ -6,17 +6,19 @@ export abstract class ARCommonGeometryNode extends ARCommonNode {
   constructor(options: ARAddGeometryOptions, node: SCNNode) {
     super(options, node);
 
-    if (options.materials) {
-      const materialArray: NSMutableArray<any> = NSMutableArray.alloc().initWithCapacity(options.materials.length);
-      options.materials.map(material => materialArray.addObject(ARMaterialFactory.getMaterial(material)));
-      node.geometry.materials = materialArray;
-    }
-  }
+		if (options.materials) {
+			ARCommonGeometryNode.applyMaterial(node, options.materials);
+		}
+	}
 
-	public setMaterials(materials: Array<string | Color | ARMaterial>) {
+	protected static applyMaterial(node: SCNNode, materials: Array<string | Color | ARMaterial>): void {
 		const materialArray: NSMutableArray<any> = NSMutableArray.alloc().initWithCapacity(materials.length);
 		materials.map(material => materialArray.addObject(ARMaterialFactory.getMaterial(material)));
-		this.ios.geometry.materials = materialArray;
+		node.geometry.materials = materialArray;
+	}
+
+	public setMaterials(materials: Array<string | Color | ARMaterial>) {
+		ARCommonGeometryNode.applyMaterial(this.ios, materials);
 	}
 
 }

--- a/src/nodes/ios/arcommongeometry.ts
+++ b/src/nodes/ios/arcommongeometry.ts
@@ -1,4 +1,4 @@
-import { ARAddGeometryOptions } from "../../ar-common";
+import { ARAddGeometryOptions, ARMaterial, Color } from "../../ar-common";
 import { ARCommonNode } from "./arcommon";
 import { ARMaterialFactory } from "./armaterialfactory";
 
@@ -12,4 +12,11 @@ export abstract class ARCommonGeometryNode extends ARCommonNode {
       node.geometry.materials = materialArray;
     }
   }
+
+	public setMaterials(materials: Array<string | Color | ARMaterial>) {
+		const materialArray: NSMutableArray<any> = NSMutableArray.alloc().initWithCapacity(materials.length);
+		materials.map(material => materialArray.addObject(ARMaterialFactory.getMaterial(material)));
+		this.ios.geometry.materials = materialArray;
+	}
+
 }


### PR DESCRIPTION
implements the following methods on ARNodes:
-setPosition
-setWorldPosition
-setRotation
-setMaterials
-setScale
-setVisible

this also fixes moveBy method on android 