### PR TITLE
added new node type (empty node)

### DIFF
--- a/src/ar.android.ts
+++ b/src/ar.android.ts
@@ -17,7 +17,7 @@ declare const com, android, global, java: any;
 let _fragment;
 let _origin;
 
-const addNode = (options: ARAddOptions, parentNode: SCNNode): Promise<ARGroup> => {
+const addNode = (options: ARAddOptions, parentNode: com.google.ar.sceneform.Node): Promise<ARGroup> => {
   return new Promise((resolve, reject) => {
     ARGroup.create(options, _fragment)
       .then((group: ARGroup) => {

--- a/src/ar.android.ts
+++ b/src/ar.android.ts
@@ -4,9 +4,11 @@ import * as utils from "tns-core-modules/utils/utils";
 
 import { AR as ARBase, ARAddOptions, ARAddBoxOptions, ARAddModelOptions, ARAddSphereOptions, ARAddTextOptions, ARAddTubeOptions, ARDebugLevel, ARLoadedEventData, ARNode, ARPlaneTappedEventData, ARTrackingMode } from "./ar-common";
 import { ARBox } from "./nodes/android/arbox";
+import { ARCommonNode } from "./nodes/android/arcommon";
 import { ARSphere } from "./nodes/android/arsphere";
 import { ARTube } from "./nodes/android/artube";
 import { ARModel } from "./nodes/android/armodel";
+import { ARGroup } from "./nodes/android/argroup";
 
 import { FragmentScreenGrab } from "./screengrab-android";
 
@@ -14,6 +16,16 @@ declare const com, android, global, java: any;
 
 let _fragment;
 let _origin;
+
+const addNode = (options: ARAddOptions, parentNode: SCNNode): Promise<ARGroup> => {
+  return new Promise((resolve, reject) => {
+    ARGroup.create(options, _fragment)
+      .then((group: ARGroup) => {
+        group.android.setParent(parentNode);
+        resolve(group);
+      });
+  });
+};
 
 const addModel = (options: ARAddModelOptions, parentNode: com.google.ar.sceneform.Node): Promise<ARModel> => {
   return new Promise((resolve, reject) => {
@@ -355,6 +367,13 @@ export class AR extends ARBase {
     return null;
   }
 
+  addNode(options: ARAddOptions): Promise<ARGroup> {
+    return new Promise((resolve, reject) => {
+
+      addNode(options, resolveParentNode(options))
+          .then(model => resolve(model));
+    });
+  }
 
   addModel(options: ARAddModelOptions): Promise<ARNode> {
     return new Promise((resolve, reject) => {

--- a/src/ar.ios.ts
+++ b/src/ar.ios.ts
@@ -8,6 +8,7 @@ import { ARPlane } from "./nodes/ios/arplane";
 import { ARSphere } from "./nodes/ios/arsphere";
 import { ARText } from "./nodes/ios/artext";
 import { ARTube } from "./nodes/ios/artube";
+import { ARGroup } from "./nodes/ios/argroup";
 
 import { ImageSource, fromNativeSource } from "tns-core-modules/image-source";
 
@@ -20,6 +21,15 @@ const ARState = {
   shapes: new Map<string, ARCommonNode>(),
 };
 
+const addNode = (options: ARAddOptions, parentNode: SCNNode): Promise<ARGroup> => {
+  return new Promise((resolve, reject) => {
+    const group = ARGroup.create(options)
+    ARState.shapes.set(group.id, group);
+    parentNode.addChildNode(group.ios);
+    resolve(group);
+
+  });
+};
 
 const addText = (options: ARAddTextOptions, parentNode: SCNNode): Promise<ARBox> => {
   return new Promise((resolve, reject) => {
@@ -38,6 +48,7 @@ const addBox = (options: ARAddBoxOptions, parentNode: SCNNode): Promise<ARBox> =
     resolve(box);
   });
 };
+
 
 const addModel = (options: ARAddModelOptions, parentNode: SCNNode): Promise<ARModel> => {
   return new Promise((resolve, reject) => {
@@ -518,6 +529,10 @@ export class AR extends ARBase {
       };
       this.notify(eventData);
     }
+  }
+
+  addNode(options: ARAddModelOptions): Promise<ARGroup> {
+    return addNode(options, this.resolveParentNode(options));
   }
 
   addModel(options: ARAddModelOptions): Promise<ARNode> {

--- a/src/nodes/android/argroup.ts
+++ b/src/nodes/android/argroup.ts
@@ -1,0 +1,13 @@
+import { ARAddOptions } from "../../ar-common";
+import { ARCommonNode } from "./arcommon";
+
+export class ARGroup extends ARCommonNode {
+
+  static create(options: ARAddOptions, fragment): Promise<ARGroup> {
+    return new Promise<ARGroup>(async (resolve, reject) => {
+      const node = new com.google.ar.sceneform.ux.TransformableNode(fragment.getTransformationSystem());
+      node.select(); // optional; this can be removed
+      resolve(new ARGroup(options, node));
+    });
+  }
+}

--- a/src/nodes/ios/argroup.ts
+++ b/src/nodes/ios/argroup.ts
@@ -1,0 +1,8 @@
+import { ARAddTextOptions } from "../../ar-common";
+import { ARCommonGeometryNode } from "./arcommongeometry";
+
+export class ARGroup extends ARCommonNode {
+  static create(options: ARAddOptions) {
+    return new ARGroup(options, SCNNode.node());
+  }
+}

--- a/src/nodes/ios/argroup.ts
+++ b/src/nodes/ios/argroup.ts
@@ -1,5 +1,5 @@
-import { ARAddTextOptions } from "../../ar-common";
-import { ARCommonGeometryNode } from "./arcommongeometry";
+import { ARAddOptions } from "../../ar-common";
+import { ARCommonNode } from "./arcommon";
 
 export class ARGroup extends ARCommonNode {
   static create(options: ARAddOptions) {


### PR DESCRIPTION
added a new ar method 'adNode', that creates an empty node. It can be used to group other items and is useful for creating local animations etc