### PR TITLE
use Transformable node if dragging/rotating (android)

### DIFF
--- a/src/nodes/android/arbox.ts
+++ b/src/nodes/android/arbox.ts
@@ -6,7 +6,7 @@ export class ARBox extends ARCommonGeometryNode {
 
   static create(options: ARAddBoxOptions, fragment): Promise<ARBox> {
     return new Promise<ARBox>(async (resolve, reject) => {
-      const node = new com.google.ar.sceneform.ux.TransformableNode(fragment.getTransformationSystem());
+      const node = ARCommonNode.createNode(options, fragment);
 
       const defaultMaterial = await ARCommonNode.getDefaultMaterial();
 
@@ -24,7 +24,6 @@ export class ARBox extends ARCommonGeometryNode {
 
       node.setRenderable(renderable);
 
-      node.select(); // optional; this can be removed
       resolve(new ARBox(options, node));
     });
   }

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -37,19 +37,6 @@ export abstract class ARCommonNode implements IARCommonNode {
     this.draggingEnabled = options.draggingEnabled;
     this.rotatingEnabled = options.rotatingEnabled;
 
-    if(node instanceof com.google.ar.sceneform.ux.TransformableNode){
-      if(!this.draggingEnabled){
-        node.getTranslationController().isEnabled=false;
-      }
-      if(!this.rotatingEnabled){
-        node.getRotationController().isEnabled=false;
-      }
-
-      if(!(this.draggingEnabled||this.rotatingEnabled)){
-         node.getScaleController().isEnabled=false;
-      }
-    }
-
     if (options.rotation) {
       this.rotateBy(options.rotation);
     }

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -13,7 +13,20 @@ export abstract class ARCommonNode implements IARCommonNode {
   draggingEnabled: boolean;
   rotatingEnabled: boolean;
 
+
+  public static createNode(options:ARAddOptions, fragment){
+
+    if((options.draggingEnabled||options.rotatingEnabled)){
+      const node= new com.google.ar.sceneform.ux.TransformableNode(fragment.getTransformationSystem());
+      node.select();
+      return node;
+    }
+
+    return new com.google.ar.sceneform.Node();
+  }
+
   private static defaultMaterial: com.google.ar.sceneform.rendering.Material;
+
 
   constructor(options: ARAddOptions, node: com.google.ar.sceneform.Node) {
     this.android = node;

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -24,6 +24,17 @@ export abstract class ARCommonNode implements IARCommonNode {
     this.draggingEnabled = options.draggingEnabled;
     this.rotatingEnabled = options.rotatingEnabled;
 
+    if(!this.draggingEnabled){
+      node.getTranslationController().isEnabled=false;
+    }
+    if(!this.rotatingEnabled){
+      node.getRotationController().isEnabled=false;
+    }
+
+    if(!(this.draggingEnabled||this.rotatingEnabled)){
+       node.getScaleController().isEnabled=false;
+    }
+
     if (options.rotation) {
       this.rotateBy(options.rotation);
     }

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -28,7 +28,7 @@ export abstract class ARCommonNode implements IARCommonNode {
   private static defaultMaterial: com.google.ar.sceneform.rendering.Material;
 
 
-  constructor(options: ARAddOptions, node: com.google.ar.sceneform.Node) {
+  constructor(options: ARAddOptions, node: com.google.ar.sceneform.Node|com.google.ar.sceneform.ux.TransformableNode) {
     this.android = node;
 
     this.onTapHandler = options.onTap;
@@ -37,15 +37,17 @@ export abstract class ARCommonNode implements IARCommonNode {
     this.draggingEnabled = options.draggingEnabled;
     this.rotatingEnabled = options.rotatingEnabled;
 
-    if(!this.draggingEnabled){
-      node.getTranslationController().isEnabled=false;
-    }
-    if(!this.rotatingEnabled){
-      node.getRotationController().isEnabled=false;
-    }
+    if(node instanceof com.google.ar.sceneform.ux.TransformableNode){
+      if(!this.draggingEnabled){
+        node.getTranslationController().isEnabled=false;
+      }
+      if(!this.rotatingEnabled){
+        node.getRotationController().isEnabled=false;
+      }
 
-    if(!(this.draggingEnabled||this.rotatingEnabled)){
-       node.getScaleController().isEnabled=false;
+      if(!(this.draggingEnabled||this.rotatingEnabled)){
+         node.getScaleController().isEnabled=false;
+      }
     }
 
     if (options.rotation) {

--- a/src/nodes/android/argroup.ts
+++ b/src/nodes/android/argroup.ts
@@ -5,8 +5,7 @@ export class ARGroup extends ARCommonNode {
 
   static create(options: ARAddOptions, fragment): Promise<ARGroup> {
     return new Promise<ARGroup>(async (resolve, reject) => {
-      const node = new com.google.ar.sceneform.ux.TransformableNode(fragment.getTransformationSystem());
-      node.select(); // optional; this can be removed
+      const node = ARCommonNode.createNode(options, fragment);
       resolve(new ARGroup(options, node));
     });
   }

--- a/src/nodes/android/armodel.ts
+++ b/src/nodes/android/armodel.ts
@@ -12,9 +12,8 @@ export class ARModel extends ARCommonNode {
           .build()
           .thenAccept(new java.util.function.Consumer({
             accept: renderable => {
-              const transformableNode = new com.google.ar.sceneform.ux.TransformableNode(fragment.getTransformationSystem());
+              const transformableNode = ARCommonNode.createNode(options, fragment);
               transformableNode.setRenderable(renderable);
-              transformableNode.select(); // optional; this can be removed
               resolve(new ARModel(options, transformableNode));
             }
             // TODO add the exception case

--- a/src/nodes/android/arsphere.ts
+++ b/src/nodes/android/arsphere.ts
@@ -6,7 +6,7 @@ export class ARSphere extends ARCommonGeometryNode {
 
   static create(options: ARAddSphereOptions, fragment): Promise<ARSphere> {
     return new Promise<ARSphere>(async (resolve, reject) => {
-      const node = new com.google.ar.sceneform.ux.TransformableNode(fragment.getTransformationSystem());
+      const node = ARCommonNode.createNode(options, fragment);
 
       const defaultMaterial = await ARCommonNode.getDefaultMaterial();
 
@@ -21,7 +21,6 @@ export class ARSphere extends ARCommonGeometryNode {
 
       node.setRenderable(renderable);
 
-      node.select(); // optional; this can be removed
       resolve(new ARSphere(options, node));
     });
   }

--- a/src/nodes/android/artube.ts
+++ b/src/nodes/android/artube.ts
@@ -6,7 +6,7 @@ export class ARTube extends ARCommonGeometryNode {
 
   static create(options: ARAddTubeOptions, fragment): Promise<ARTube> {
     return new Promise<ARTube>(async (resolve, reject) => {
-      const node = new com.google.ar.sceneform.ux.TransformableNode(fragment.getTransformationSystem());
+      const node = ARCommonNode.createNode(options, fragment);
 
       const defaultMaterial = await ARCommonNode.getDefaultMaterial();
 
@@ -23,7 +23,6 @@ export class ARTube extends ARCommonGeometryNode {
 
       node.setRenderable(renderable);
 
-      node.select(); // optional; this can be removed
       resolve(new ARTube(options, node));
     });
   }


### PR DESCRIPTION
if node is created with draggingEnabled or rotatingEnabled then uses a Transformable node
otherwise uses a plain Node. 

Transformable node was preventing programatically changing scale (#49) and initial scales outside of 0.75 -1.75 range 