### PR TITLE
Support lookAt* methods

### DIFF
--- a/demo-solarsystem/app/components/App.vue
+++ b/demo-solarsystem/app/components/App.vue
@@ -270,10 +270,19 @@
                     this.hasControlPanel = true;
                     ar.addUIView({
                       position: {x: 0, y: .22, z: 0},
+                      // dimensions:{x:1, y:0.8}, //ios might need this
                       parentNode: objectNode,
                       view: this.page.getViewById("controlPanel"),
                       // 0.35 for Android
                       scale: 0.5 // TODO (in the plugin code).. prolly do something with screen density
+                    }).then(view=>{
+                        setInterval(()=>{
+                          try{
+                            view.lookAtWorldPosition(ar.getCameraPosition());
+                          }catch(e){
+                            console.error(e);
+                          }
+                        }, 100);
                     });
                   }
                 } else {

--- a/src/ar.android.ts
+++ b/src/ar.android.ts
@@ -1,7 +1,7 @@
 import * as application from "tns-core-modules/application";
 import { ImageSource } from "tns-core-modules/image-source";
 import * as utils from "tns-core-modules/utils/utils";
-import { AR as ARBase, ARAddBoxOptions, ARAddImageOptions, ARAddModelOptions, ARAddOptions, ARAddPlaneOptions, ARAddSphereOptions, ARAddTextOptions, ARAddTubeOptions, ARAddVideoOptions, ARCommonNode, ARDebugLevel, ARLoadedEventData, ARPlaneTappedEventData, ARTrackingMode, ARUIViewOptions, ARVideoNode } from "./ar-common";
+import { AR as ARBase, ARAddBoxOptions, ARAddImageOptions, ARAddModelOptions, ARAddOptions, ARAddPlaneOptions, ARAddSphereOptions, ARAddTextOptions, ARAddTubeOptions, ARAddVideoOptions, ARCommonNode, ARDebugLevel, ARLoadedEventData, ARPlaneTappedEventData, ARTrackingMode, ARUIViewOptions, ARVideoNode, ARPosition } from "./ar-common";
 import { ARBox } from "./nodes/android/arbox";
 import { ARGroup } from "./nodes/android/argroup";
 import { ARImage } from "./nodes/android/arimage";
@@ -176,6 +176,13 @@ export class AR extends ARBase {
     // } else {
     this.initAR();
     // }
+  }
+
+
+  public getCameraPosition():ARPosition{
+    let p = Array.create("float", 3);
+    _fragment.getArSceneView().getArFrame().getCamera().getPose().getTranslation(p, 0);
+    return {x:p[0], y:p[1], z:p[2]};
   }
 
   private initAR() {

--- a/src/ar.ios.ts
+++ b/src/ar.ios.ts
@@ -215,6 +215,12 @@ export class AR extends ARBase {
     });
   }
 
+
+  public getCameraPosition():ARPosition{
+    var p = this.sceneView.defaultCameraController.pointOfView.worldPosition;
+     return {x:p.x, y:p.y, z:p.z}
+  }
+
   private initAR() {
     if (!AR.isSupported()) {
       console.log("############### AR is not supported on this device.");

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -111,6 +111,25 @@ export abstract class ARCommonNode implements IARCommonNode {
     );
   }
 
+
+  getPosition():ARPosition{
+    const pos = this.android.getLocalPosition();
+    return {
+      x: pos.x,
+      y: pos.y,
+      z: pos.z
+    }
+  }
+
+  getWorldPosition():ARPosition{
+    const pos = this.android.getWorldPosition();
+    return {
+      x: pos.x,
+      y: pos.y,
+      z: pos.z
+    }
+  }
+
   setPosition(pos: ARPosition): void {
     this.android.setLocalPosition(
         new (<any>com.google.ar.sceneform).math.Vector3(
@@ -154,6 +173,31 @@ export abstract class ARCommonNode implements IARCommonNode {
             )
         )
     );
+  }
+
+
+  lookAtWorldPosition(worldPos: ARPosition): void {
+    var direction = (<any>com.google.ar.sceneform).math.Vector3.subtract(new (<any>com.google.ar.sceneform).math.Vector3(
+            worldPos.x,
+            worldPos.y,
+            worldPos.z
+        ), this.android.getWorldPosition());
+    this.android.setLookDirection(direction, (<any>com.google.ar.sceneform).math.Vector3.up());
+  }
+
+  lookAtPosition(localPos: ARPosition): void {
+
+    var direction = (<any>com.google.ar.sceneform).math.Vector3.subtract(
+      this.android.localToWorldPoint(new (<any>com.google.ar.sceneform).math.Vector3(
+            localPos.x,
+            localPos.y,
+            localPos.z
+        )), this.android.getWorldPosition());
+    this.android.setLookDirection(direction, (<any>com.google.ar.sceneform).math.Vector3.up());
+  }
+  
+  lookAtNode(node: ARCommonNode):void{
+    this.lookAtWorldPosition(node.getWorldPosition())
   }
 
   scaleBy(by: number | ARScale): void {

--- a/src/nodes/ios/arcommon.ts
+++ b/src/nodes/ios/arcommon.ts
@@ -61,6 +61,24 @@ export abstract class ARCommonNode implements IARCommonNode {
     };
   }
 
+  getPosition():ARPosition{
+    const pos=this.ios.position;
+    return {
+      x: pos.x,
+      y: pos.y,
+      z: pos.z
+    }
+  }
+
+  getWorldPosition():ARPosition{
+    const pos=this.ios.worldPosition;
+    return {
+      x: pos.x,
+      y: pos.y,
+      z: pos.z
+    }
+  }
+
   setPosition(pos: ARPosition): void {
 
     this.ios.position = {
@@ -97,6 +115,19 @@ export abstract class ARCommonNode implements IARCommonNode {
       z: ARCommonNode.degToRadians(rot.z)
     };
   }
+
+
+  lookAtWorldPosition(worldPos: ARPosition): void {
+    this.ios.lookAt(worldPos); //,  {x:0, y:1, z:0},  {x:0, y:0, z:1}
+  }
+  lookAtPosition(localPos: ARPosition): void {
+    const worldPos = this.ios.convertPositionToNode(localPos, null);
+    this.lookAtWorldPosition(worldPos);
+  }
+  lookAtNode(node: ARCommonNode):void{
+    this.lookAtWorldPosition(node.getWorldPosition())
+  }
+
 
 
   scaleBy(by: number | ARScale): void {
@@ -139,6 +170,8 @@ export abstract class ARCommonNode implements IARCommonNode {
   setVisible(visible: boolean): void {
     this.ios.hidden = !visible;
   }
+
+
 
   allowDragging(): boolean {
     return this.draggingEnabled;


### PR DESCRIPTION
add arcommon node methods:
getPosition
getWorldPosition

lookAtWorldPosition
lookAtPosition (local ~less usefull)
lookAtNode (ARCommonNode)

add ar method:
getCameraPosition


update solar system demo:
control panel `view.lookAtWorldPosition(ar.getCameraPosition());`