### PR TITLE
invert lookAt and fix uiview interactions on ios 

### DIFF
--- a/demo-solarsystem/app/components/App.vue
+++ b/demo-solarsystem/app/components/App.vue
@@ -276,7 +276,10 @@
                     }).then(view => {
                       setInterval(() => {
                         try {
-                          view.lookAtWorldPosition(ar.getCameraPosition());
+                          let p=view.getWorldPosition();
+                          let c=ar.getCameraPosition();
+                          c.y=p.y;
+                          view.lookAtWorldPosition(c);
                         } catch (e) {
                           console.error(e);
                         }

--- a/src/nodes/android/arcommon.ts
+++ b/src/nodes/android/arcommon.ts
@@ -177,21 +177,22 @@ export abstract class ARCommonNode implements IARCommonNode {
 
 
   lookAtWorldPosition(worldPos: ARPosition): void {
-    const direction = (<any>com.google.ar.sceneform).math.Vector3.subtract(new (<any>com.google.ar.sceneform).math.Vector3(
+    const direction = (<any>com.google.ar.sceneform).math.Vector3.subtract(this.android.getWorldPosition(), new (<any>com.google.ar.sceneform).math.Vector3(
         worldPos.x,
         worldPos.y,
         worldPos.z
-    ), this.android.getWorldPosition());
+    ));
     this.android.setLookDirection(direction, (<any>com.google.ar.sceneform).math.Vector3.up());
   }
 
   lookAtPosition(localPos: ARPosition): void {
     const direction = (<any>com.google.ar.sceneform).math.Vector3.subtract(
+        this.android.getWorldPosition(),
         this.android.localToWorldPoint(new (<any>com.google.ar.sceneform).math.Vector3(
             localPos.x,
             localPos.y,
             localPos.z
-        )), this.android.getWorldPosition());
+        )));
     this.android.setLookDirection(direction, (<any>com.google.ar.sceneform).math.Vector3.up());
   }
 

--- a/src/nodes/ios/aruiview.ts
+++ b/src/nodes/ios/aruiview.ts
@@ -26,8 +26,11 @@ export class ARUIView extends ARCommonNode {
       const stackLayout = new StackLayout();
 
       if (view.parent) {
-        (<LayoutBase>view.parent).removeChild(view);
+        //(<LayoutBase>view.parent).removeChild(view);
+        view.ios.removeFromSuperview();
+        view.parent=null;
       }
+
 
       stackLayout.addChild(view);
 
@@ -111,7 +114,7 @@ class ArPlaneViewController extends UIViewController {
 
       this.materialPlane.firstMaterial.diffuse.contents = this.view;
       this.materialPlane.firstMaterial.doubleSided = true;
-      this.childView.requestLayout();
+      //this.childView.requestLayout();
 
     } catch (e) {
       console.error(e);

--- a/src/nodes/ios/aruiview.ts
+++ b/src/nodes/ios/aruiview.ts
@@ -23,7 +23,7 @@ export class ARUIView extends ARCommonNode {
       }
 
       const view = options.view;
-      const stackLayout = new StackLayout();
+      //const stackLayout = new StackLayout();
 
       if (view.parent) {
         //(<LayoutBase>view.parent).removeChild(view);
@@ -31,8 +31,7 @@ export class ARUIView extends ARCommonNode {
         (<any>view).parent=null;
       }
 
-
-      stackLayout.addChild(view);
+      //stackLayout.addChild(view);
 
       if (view instanceof View && (!view.ios)) {
         view._setupUI({});
@@ -59,7 +58,7 @@ export class ARUIView extends ARCommonNode {
 
       materialPlane.cornerRadius = options.chamferRadius || 0;
 
-      const planeViewController = (<ArPlaneViewController>ArPlaneViewController.alloc()).initWithViewAndPlane(stackLayout, materialPlane);
+      const planeViewController = (<ArPlaneViewController>ArPlaneViewController.alloc()).initWithViewAndPlane(view, materialPlane);
 
       const planeNode = SCNNode.nodeWithGeometry(materialPlane);
       planeViewController.loadView();

--- a/src/nodes/ios/aruiview.ts
+++ b/src/nodes/ios/aruiview.ts
@@ -28,7 +28,7 @@ export class ARUIView extends ARCommonNode {
       if (view.parent) {
         //(<LayoutBase>view.parent).removeChild(view);
         view.ios.removeFromSuperview();
-        view.parent=null;
+        (<any>view).parent=null;
       }
 
 

--- a/src/nodes/ios/aruiview.ts
+++ b/src/nodes/ios/aruiview.ts
@@ -61,7 +61,16 @@ export class ARUIView extends ARCommonNode {
       const planeNode = SCNNode.nodeWithGeometry(materialPlane);
       planeViewController.loadView();
 
-      super(options, planeNode);
+
+      const node=SCNNode.node();
+      planeNode.eulerAngles = {
+        x: 0,
+        y: Math.PI,
+        z: 0
+      };
+      node.addChildNode(planeNode);
+
+      super(options, node);
 
     } catch (e) {
       console.error(e);


### PR DESCRIPTION
android lookAt was reversed. oops,
ios uiview has reversed forward direction geometry (SCNPlane: so that placing an item in front of camera displays without having to rotate 180 to face camera...)

I changed the demo so that the controls rotate only around y-axis (stay upright)