### PR TITLE
add a basic image tracking implementation for android

### DIFF
--- a/src/imagefragment.android.ts
+++ b/src/imagefragment.android.ts
@@ -1,0 +1,79 @@
+import * as utils from "tns-core-modules/utils/utils";
+
+
+export class TNSArFragmentForImageDetection extends com.google.ar.sceneform.ux.ArFragment {
+
+
+  augmentedImageDatabase:any;
+  arSceneViewPrimises=[];
+
+  constructor() {
+    super();
+    // necessary when extending TypeScript constructors
+    return global.__native(this);
+  }
+
+  getSessionConfiguration(session) {
+    const config = new (<any>com.google.ar).core.Config(session);
+    this.setupAugmentedImageDatabase(config, session);
+    return config;
+  }
+
+  public getImageDetectionSceneView():Promise<any>{
+  	return new Promise((resolve, reject)=>{
+  		const arSceneView=super.getArSceneView();
+  		if(arSceneView){
+  			resolve(arSceneView);
+  			return;
+  		}
+  		this.arSceneViewPrimises.push(resolve);
+
+  	})
+  }
+
+  onCreateView(inflater, container, savedInstanceState) {
+    const frameLayout = super.onCreateView(inflater, container, savedInstanceState);
+    super.getPlaneDiscoveryController().hide();
+    super.getPlaneDiscoveryController().setInstructionView(null);
+    super.getArSceneView().getPlaneRenderer().setEnabled(false);
+    this.arSceneViewPrimises.forEach(resolve=>{
+    	resolve(super.getArSceneView());
+    })
+    return frameLayout;
+  }
+
+  setupAugmentedImageDatabase(config,  session){
+    
+    
+
+    this.augmentedImageDatabase = new (<any>com.google.ar).core.AugmentedImageDatabase(session);
+    this.addImage('tnsgranite-diffuse.png');
+
+    config.setAugmentedImageDatabase(this.augmentedImageDatabase);
+    return true;
+  }
+
+
+  public addImage(name:string): void{
+
+  	const context=utils.ad.getApplicationContext();
+
+    const assetManager =context.getAssets();
+
+      let augmentedImageBitmap=null;
+
+       try {
+        let is = assetManager.open(name)
+        augmentedImageBitmap= android.graphics.BitmapFactory.decodeStream(is);
+      } catch (e) {
+        console.log(e);
+      }
+
+      if (augmentedImageBitmap == null) {
+        return;
+      }
+
+      this.augmentedImageDatabase.addImage(name, augmentedImageBitmap);
+  }
+
+}


### PR DESCRIPTION
Not necessarily ready to merge, but thought I'd PR so you see this...


I didn't add demo code but it would look like 
```js
export function trackingImageDetected(args: ARTrackingImageDetectedEventData): void {
if(args.imageName === "tnsgranite-diffuse.png"){
        console.log("Adding box");
        args.imageTrackingActions.addBox({
          position: {
            x: 0
            y: 0,
            z: 0
          },
          dimensions: 0.1,
          materials: [{
            diffuse: {
              contents: "tnsgranite-diffuse.png",
              wrapMode: "ClampToBorder"
            }
          }]
         
        }).then(node => console.log("Added Box"));
  }
}
```